### PR TITLE
Fix rules ordering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Changed
+
+* Inverted the order of eslintrc.json extended rules, to apply custom rules on top of them
+
 ## [1.0.4] - 2016-11-21
 ### Changed
 * Updating eslint-hashdard-config

--- a/eslintrc.json
+++ b/eslintrc.json
@@ -1,3 +1,3 @@
 {
-  "extends": ["hashdard", "standard-jsx"]
+  "extends": ["standard-jsx", "hashdard"]
 }


### PR DESCRIPTION
The `standard-jsx` package was overwritting the custom rules we we're setting in `eslint-config-hashdard`. 

Inverting the ordering fixes this problem.